### PR TITLE
Handling Non UTF-8 encodings in HDT Files

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,8 @@ To handle this we doubled the API of the HDT document by adding:
 - `search_join_bytes(...)` return an iterator of sets of solutions mapping as `py::set(py::bytes, py::bytes)`
 - `convert_tripleid_bytes(...)` return a triple as: `(py::bytes, py::bytes, py::bytes)`
 - `convert_id_bytes(...)` return a `py::bytes`
-**Parameters are the same as the standard version**
+
+**Parameters and documentation are the same as the standard version**
 
 ```python
 from hdt import HDTDocument

--- a/README.md
+++ b/README.md
@@ -66,3 +66,37 @@ for triple in triples:
 triples, cardinality = document.search_triples("", "", "", limit=10, offset=100)
 # etc ...
 ```
+
+# Handling non UTF-8 strings in python
+
+If the HDT document has been encoded with a non UTF-8 encoding the previous code won't work correctly and will result in a `UnicodeDecodeError`.
+More details on how to convert string to str from c++ to python [here](https://pybind11.readthedocs.io/en/stable/advanced/cast/strings.html)
+
+To handle this we doubled the API of the HDT document by adding:
+- `search_triples_bytes(...)` return an iterator of triples as `(py::bytes, py::bytes, py::bytes)`
+- `search_join_bytes(...)` return an iterator of sets of solutions mapping as `py::set(py::bytes, py::bytes)`
+- `convert_tripleid_bytes(...)` return a triple as: `(py::bytes, py::bytes, py::bytes)`
+- `convert_id_bytes(...)` return a `py::bytes`
+**Parameters are the same as the standard version**
+
+```python
+from hdt import HDTDocument
+
+ # Load an HDT file.
+ # Missing indexes are generated automatically, add False as the second argument to disable them
+document = HDTDocument("test.hdt")
+it = document.search_triple_bytes("", "", "")
+
+for s, p, o in it:
+  print(s, p, o) # print b'...', b'...', b'...'
+  # now decode it, or handle any error
+  try:
+    s, p, o = s.decode('UTF-8'), p.decode('UTF-8'), o.decode('UTF-8')
+  except UnicodeDecodeError as err:
+    # try another other codecs
+    pass
+```
+
+# Running the tests
+
+Install first, then install `pytest` then run `pytest tests/ --verbose`

--- a/README.md
+++ b/README.md
@@ -97,7 +97,3 @@ for s, p, o in it:
     # try another other codecs
     pass
 ```
-
-# Running the tests
-
-Install first, then install `pytest` then run `pytest tests/ --verbose`

--- a/README.rst
+++ b/README.rst
@@ -80,3 +80,40 @@ Getting started
    :target: https://callidon.github.io/pyHDT
 .. |PyPI version| image:: https://badge.fury.io/py/hdt.svg
    :target: https://badge.fury.io/py/hdt
+
+Handling non UTF-8 strings in python
+====================================
+
+If the HDT document has been encoded with a non UTF-8 encoding the
+previous code won’t work correctly and will result in a
+``UnicodeDecodeError``. More details on how to convert string to str
+from c++ to python `here`_
+
+To handle this we doubled the API of the HDT document by adding:
+
+- ``search_triples_bytes(...)`` return an iterator of triples as ``(py::bytes, py::bytes, py::bytes)``
+- ``search_join_bytes(...)`` return an iterator of sets of solutions mapping as ``py::set(py::bytes, py::bytes)``
+- ``convert_tripleid_bytes(...)`` return a triple as: ``(py::bytes, py::bytes, py::bytes)``
+- ``convert_id_bytes(...)`` return a ``py::bytes``
+
+**Parameters and documentation are the same as the standard version**
+
+.. code:: python
+
+  from hdt import HDTDocument
+
+   # Load an HDT file.
+   # Missing indexes are generated automatically, add False as the second argument to disable them
+  document = HDTDocument("test.hdt")
+  it = document.search_triple_bytes("", "", "")
+
+  for s, p, o in it:
+    print(s, p, o) # print b'...', b'...', b'...'
+    # now decode it, or handle any error
+    try:
+      s, p, o = s.decode('UTF-8'), p.decode('UTF-8'), o.decode('UTF-8')
+    except UnicodeDecodeError as err:
+      # try another other codecs
+      pass
+
+.. _here: https://pybind11.readthedocs.io/en/stable/advanced/cast/strings.html

--- a/docs/source/hdtdocument.rst
+++ b/docs/source/hdtdocument.rst
@@ -99,3 +99,40 @@ For example, ``("ex:2", "ex:type", "ex:Person") < ("ex:1", "ex:type", "ex:Person
 because their triple ids counterparts are ``(1, 2, 3)`` and ``(2, 2, 3)``.
 
 For more details about this topic, please refer to the `HDT journal article <http://www.imap.websemanticsjournal.org/preprints/index.php/ps/article/viewFile/328/333>`_.
+
+Handling non UTF-8 strings in python
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+If the HDT document has been encoded with a non UTF-8 encoding the
+previous code won’t work correctly and will result in a
+``UnicodeDecodeError``. More details on how to convert string to str
+from c++ to python `here`_
+
+To handle this we doubled the API of the HDT document by adding:
+
+- ``search_triples_bytes(...)`` return an iterator of triples as ``(py::bytes, py::bytes, py::bytes)``
+- ``search_join_bytes(...)`` return an iterator of sets of solutions mapping as ``py::set(py::bytes, py::bytes)``
+- ``convert_tripleid_bytes(...)`` return a triple as: ``(py::bytes, py::bytes, py::bytes)``
+- ``convert_id_bytes(...)`` return a ``py::bytes``
+
+**Parameters and documentation are the same as the standard version**
+
+.. code:: python
+
+  from hdt import HDTDocument
+
+   # Load an HDT file.
+   # Missing indexes are generated automatically, add False as the second argument to disable them
+  document = HDTDocument("test.hdt")
+  it = document.search_triple_bytes("", "", "")
+
+  for s, p, o in it:
+    print(s, p, o) # print b'...', b'...', b'...'
+    # now decode it, or handle any error
+    try:
+      s, p, o = s.decode('UTF-8'), p.decode('UTF-8'), o.decode('UTF-8')
+    except UnicodeDecodeError as err:
+      # try another other codecs
+      pass
+
+.. _here: https://pybind11.readthedocs.io/en/stable/advanced/cast/strings.html

--- a/include/hdt_document.hpp
+++ b/include/hdt_document.hpp
@@ -6,19 +6,27 @@
 #ifndef PYHDT_DOCUMENT_HPP
 #define PYHDT_DOCUMENT_HPP
 
+#include <pybind11/pybind11.h>
 #include "HDT.hpp"
 #include "QueryProcessor.hpp"
 #include "pyhdt_types.hpp"
 #include "triple_iterator.hpp"
+#include "triple_iterator_bytes.hpp"
 #include "tripleid_iterator.hpp"
 #include "join_iterator.hpp"
+#include "join_iterator_bytes.hpp"
 #include <list>
 #include <string>
 #include <vector>
+namespace py = pybind11;
 
 // The result of a search for a triple pattern in a HDT document:
 // a tuple (matching RDF triples, nb of matching RDF triples)
 typedef std::tuple<TripleIterator *, size_t> search_results;
+
+// The result of a search for a triple pattern in a HDT document:
+// a tuple (matching RDF triples, nb of matching RDF triples)
+typedef std::tuple<TripleIteratorBytes *, size_t> search_results_bytes;
 
 // Same as seach_results, but for an iterator over triple ids
 typedef std::tuple<TripleIDIterator *, size_t> search_results_ids;
@@ -152,6 +160,45 @@ public:
    * @return A JoinIterator* used to evaluated the join.
    */
   JoinIterator * searchJoin(std::vector<triple> patterns);
+
+  // ============== BYTES REPRESENTATION ==============
+  // Author: Arnaud GRALL - MIT License 2017-2019
+  /*!
+   * Search all matching triples for a triple pattern, whith an optional limit and offset. Returns bytes instead of string
+   * Returns a tuple<TripleIterator*, cardinality>
+   * @param subject   - Triple pattern's subject
+   * @param predicate - Triple pattern's predicate
+   * @param object    - Triple pattern's object
+   * @param limit     - (Optional) Maximum number of matching triples to read
+   * @param offset    - (Optional) Number of matching triples to skip
+   * @return A tuple (TripleIterator*, cardinality)
+   */
+  search_results_bytes searchBytes(std::string subject, std::string predicate,
+                        std::string object, unsigned int limit = 0,
+                        unsigned int offset = 0);
+  /**
+   * Evaluate a join between a set of triple patterns using a JoinIterator.
+   * @param  patterns - Set of triple patterns
+   * @return A JoinIterator* used to evaluated the join.
+   */
+  JoinIteratorBytes * searchJoinBytes(std::vector<triple> patterns);
+  /*!
+   * Convert a TripleID to a RDF triple as bytes
+   * @param  subject   - Triple's subject
+   * @param  predicate - Triple's predicate
+   * @param  object    - Triple's object
+   * @return The associated RDF triple
+   */
+  triple_bytes convertTripleIDBytes(unsigned int subject, unsigned int predicate,
+                     unsigned int object);
+
+  /**
+   * Convert an Object Identifier into the equivalent an RDF term as bytes
+   * @param  id  - Object Identifier
+   * @param  pos - Identifier position (subject, predicate or object)
+   * @return The an RDF term equivalent to the Object Identifier
+   */
+  py::bytes convertIDBytes(unsigned int id, IdentifierPosition pos);
 };
 
 #endif /* PYHDT_DOCUMENT_HPP */

--- a/include/join_iterator_bytes.hpp
+++ b/include/join_iterator_bytes.hpp
@@ -1,0 +1,72 @@
+/**
+ * join_iterator.hpp
+ * Author: Arnaud Grall - MIT License 2017-2019
+ */
+
+#ifndef JOIN_ITERATOR_BYTES_HPP
+#define JOIN_ITERATOR_BYTES_HPP
+
+#include "pyhdt_types.hpp"
+#include "QueryProcessor.hpp"
+#include <string>
+
+/*!
+ * JoinIterator iterates over solution bindings of a join
+ * @author Arnaud Grall
+ */
+class JoinIteratorBytes {
+private:
+  hdt::VarBindingString *iterator;
+  bool hasNextSolution = true;
+
+public:
+  /*!
+   * Constructor
+   * @param iterator [description]
+   */
+  JoinIteratorBytes(hdt::VarBindingString *_it);
+
+  /*!
+   * Destructor
+   */
+  ~JoinIteratorBytes();
+
+  /*!
+   * Implementation for Python function "__repr__"
+   * @return [description]
+   */
+  std::string python_repr();
+
+  /*!
+   * Implementation for Python function "__iter__"
+   * @return [description]
+   */
+  JoinIteratorBytes *python_iter();
+
+  /**
+   * Get the estimated join cardinality
+   * @return [description]
+   */
+  size_t estimatedCardinality();
+
+  /**
+   * Reset the iterator into its initial state and restart join processing.
+   */
+  void reset();
+
+  /*!
+   * Return true if the iterator still has items available, False otherwise.
+   * @return [description]
+   */
+  bool hasNext();
+
+  /**
+   * Return the next set of solutions bindings, or raise py::StopIteration if the iterator
+   * has ended. Used to implement Python Itertor protocol.
+   * @return [description]
+   */
+  py::set next();
+
+};
+
+#endif /* JOIN_ITERATOR_BYTES_HPP */

--- a/include/pyhdt_types.hpp
+++ b/include/pyhdt_types.hpp
@@ -1,6 +1,6 @@
 /**
  * hdt_types.hpp
- * Author: Thomas MINIER - MIT License 2017-2019
+ * Author: Thomas MINIER, Arnaud Grall - MIT License 2017-2019
  */
 
 #ifndef PYHDT_TYPES_HPP
@@ -10,6 +10,8 @@
 #include <string>
 #include <tuple>
 #include <set>
+#include <pybind11/pybind11.h>
+namespace py = pybind11;
 
 /**
  * Indictates the position of an Object Identifier
@@ -39,5 +41,11 @@ typedef std::tuple<size_t, bool> size_hint;
 typedef std::tuple<std::string, std::string> single_binding;
 
 typedef std::set<single_binding> *solution_bindings;
+
+// ============== BYTES REPRESENTATION ==============
+// A RDF Triple. RDF terms are represented as simple bytes by HDT.
+typedef std::tuple<py::bytes, py::bytes, py::bytes> triple_bytes;
+// A Set of solutions bindings for the join iterator
+typedef py::set solution_bindings_bytes;
 
 #endif /* PYHDT_TYPES_HPP */

--- a/include/triple_iterator_bytes.hpp
+++ b/include/triple_iterator_bytes.hpp
@@ -1,0 +1,114 @@
+/**
+ * triple_iterator_bytes.hpp
+ * Author: Arnaud GRALL - MIT License 2017-2019
+ */
+
+#ifndef TRIPLE_ITERATOR_BYTES_HPP
+#define TRIPLE_ITERATOR_BYTES_HPP
+
+#include "tripleid_iterator.hpp"
+#include "pyhdt_types.hpp"
+#include "Dictionary.hpp"
+#include <string>
+
+/*!
+ * TripleIterator iterates over RDF triples of an HDT document which match a
+ * triple pattern + limit + offset \author Thomas Minier
+ */
+class TripleIteratorBytes {
+private:
+  TripleIDIterator *iterator;
+  hdt::Dictionary *dictionary;
+
+public:
+  /*!
+   * Constructor
+   * @param iterator [description]
+   */
+  TripleIteratorBytes(TripleIDIterator *_it, hdt::Dictionary *_dict);
+
+  /*!
+   * Destructor
+   */
+  ~TripleIteratorBytes();
+
+  /*!
+   * Implementation for Python function "__repr__"
+   * @return [description]
+   */
+  std::string python_repr();
+
+  /*!
+   * Get the subject of the triple pattern currently evaluated.
+   * An empty string represents a variable
+   * @return [description]
+   */
+  std::string getSubject();
+
+  /*!
+   * Get the predicate of the triple pattern currently evaluated.
+   * An empty string represents a variable
+   * @return [description]
+   */
+  std::string getPredicate();
+
+  /*!
+   * Get the object of the triple pattern currently evaluated.
+   * An empty string represents a variable
+   * @return [description]
+   */
+  std::string getObject();
+
+  /*!
+   * Get the limit of the current iterator
+   * @return [description]
+   */
+  unsigned int getLimit();
+
+  /*!
+   * Get the offset of the current iterator
+   * @return [description]
+   */
+  unsigned int getOffset();
+
+  /*!
+   * Get the number of results read by the iterator
+   * @return [description]
+   */
+  unsigned int getNbResultsRead();
+
+  /*!
+   * Implementation for Python function "__iter__"
+   * @return [description]
+   */
+  TripleIteratorBytes *python_iter();
+
+  /*!
+   * Get the estimated cardinality of the pattern currently evaluated.
+   * Offset & limit are not taken into account.
+   * @return [description]
+   */
+  size_hint sizeHint();
+
+  /*!
+   * Return true if the iterator still has items available, False otherwise.
+   * @return [description]
+   */
+  bool hasNext();
+
+  /**
+   * Get the next item in the iterator, or raise py::StopIteration if the
+   * iterator has ended
+   * @return [description]
+   */
+  triple_bytes next();
+
+  /**
+   * Get the next item in the iterator, or raise py::StopIteration if the
+   * iterator has ended, but without advancing the iterator.
+   * @return [description]
+   */
+  triple_bytes peek();
+};
+
+#endif /* TRIPLE_ITERATOR_BYTES_HPP */

--- a/install.sh
+++ b/install.sh
@@ -4,12 +4,12 @@
 echo "Validating dependencies..."
 command -v python >/dev/null 2>&1 || { echo >&2 "Python is required for the installation of pyHDT! Aborting installation..."; exit 1; }
 command -v pip >/dev/null 2>&1 || { echo >&2 "pip is required for the installation of pyHDT! Aborting installation..."; exit 1; }
-command -v wget >/dev/null 2>&1 || { echo >&2 "wget is required for the installation of pyHDT! Aborting installation..."; exit 1; }
+command -v curl >/dev/null 2>&1 || { echo >&2 "curl is required for the installation of pyHDT! Aborting installation..."; exit 1; }
 command -v unzip >/dev/null 2>&1 || { echo >&2 "unzip is required for the installation of pyHDT! Aborting installation..."; exit 1; }
 
 echo "Downloading HDT..."
-wget https://github.com/rdfhdt/hdt-cpp/archive/v1.3.3.zip
-unzip v1.3.3.zip
+curl -LO https://github.com/rdfhdt/hdt-cpp/archive/v1.3.3.zip
+unzip -qq v1.3.3.zip
 
 echo "Installing pybind11..."
 pip install -r requirements.txt

--- a/setup.py
+++ b/setup.py
@@ -22,8 +22,10 @@ sources = [
     "src/hdt.cpp",
     "src/hdt_document.cpp",
     "src/triple_iterator.cpp",
+    "src/triple_iterator_bytes.cpp",
     "src/tripleid_iterator.cpp",
-    "src/join_iterator.cpp"
+    "src/join_iterator.cpp",
+    "src/join_iterator_bytes.cpp"
 ]
 
 # HDT source files

--- a/src/hdt.cpp
+++ b/src/hdt.cpp
@@ -9,8 +9,10 @@
 #include "docstrings.hpp"
 #include "hdt_document.hpp"
 #include "triple_iterator.hpp"
+#include "triple_iterator_bytes.hpp"
 #include "tripleid_iterator.hpp"
 #include "join_iterator.hpp"
+#include "join_iterator_bytes.hpp"
 
 namespace py = pybind11;
 
@@ -46,6 +48,29 @@ PYBIND11_MODULE(hdt, m) {
                     TRIPLE_ITERATOR_NBREADS_DOC)
       .def("__repr__", &TripleIterator::python_repr);
 
+  py::class_<TripleIteratorBytes>(m, "TripleIteratorBytes", TRIPLE_ITERATOR_CLASS_DOC)
+      .def("next", &TripleIteratorBytes::next, TRIPLE_ITERATOR_NEXT_DOC)
+      .def("__next__", &TripleIteratorBytes::next, TRIPLE_ITERATOR_NEXT_DOC)
+      .def("peek", &TripleIteratorBytes::peek, TRIPLE_ITERATOR_PEEK_DOC)
+      .def("has_next", &TripleIteratorBytes::hasNext, TRIPLE_ITERATOR_HASNEXT_DOC)
+      .def("size_hint", &TripleIteratorBytes::sizeHint, TRIPLE_ITERATOR_SIZE_DOC)
+      .def("__len__", &TripleIteratorBytes::sizeHint,
+           TRIPLE_ITERATOR_SIZE_DOC)
+      .def("__iter__", &TripleIteratorBytes::python_iter)
+      .def_property_readonly("subject", &TripleIteratorBytes::getSubject,
+                             TRIPLE_ITERATOR_GETSUBJECT_DOC)
+      .def_property_readonly("predicate", &TripleIteratorBytes::getPredicate,
+                             TRIPLE_ITERATOR_GETPREDICATE_DOC)
+      .def_property_readonly("object", &TripleIteratorBytes::getObject,
+                             TRIPLE_ITERATOR_GETOBJECT_DOC)
+      .def_property_readonly("limit", &TripleIteratorBytes::getLimit,
+                             TRIPLE_ITERATOR_GETLIMIT_DOC)
+      .def_property_readonly("offset", &TripleIteratorBytes::getOffset,
+                             TRIPLE_ITERATOR_GETOFFSET_DOC)
+      .def_property_readonly("nb_reads", &TripleIteratorBytes::getNbResultsRead,
+                    TRIPLE_ITERATOR_NBREADS_DOC)
+      .def("__repr__", &TripleIteratorBytes::python_repr);
+
   py::class_<TripleIDIterator>(m, "TripleIDIterator", TRIPLE_ID_ITERATOR_CLASS_DOC)
       .def("next", &TripleIDIterator::next, TRIPLE_ITERATOR_NEXT_DOC)
       .def("__next__", &TripleIDIterator::next, TRIPLE_ITERATOR_NEXT_DOC)
@@ -77,6 +102,16 @@ PYBIND11_MODULE(hdt, m) {
     .def("__next__", &JoinIterator::next, JOIN_ITERATOR_NEXT_DOC)
     .def("__iter__", &JoinIterator::python_iter)
     .def("__repr__", &JoinIterator::python_repr);
+
+  py::class_<JoinIteratorBytes>(m, "JoinIteratorBytes", JOIN_ITERATOR_CLASS_DOC)
+    .def("next", &JoinIteratorBytes::next, JOIN_ITERATOR_NEXT_DOC)
+    .def("has_next", &JoinIteratorBytes::hasNext, JOIN_ITERATOR_HAS_NEXT_DOC)
+    .def("cardinality", &JoinIteratorBytes::estimatedCardinality, JOIN_ITERATOR_SIZE_DOC)
+    .def("reset", &JoinIteratorBytes::reset, JOIN_ITERATOR_RESET_DOC)
+    .def("__len__", &JoinIteratorBytes::estimatedCardinality, JOIN_ITERATOR_SIZE_DOC)
+    .def("__next__", &JoinIteratorBytes::next, JOIN_ITERATOR_NEXT_DOC)
+    .def("__iter__", &JoinIteratorBytes::python_iter)
+    .def("__repr__", &JoinIteratorBytes::python_repr);
 
   py::class_<HDTDocument>(m, "HDTDocument", HDT_DOCUMENT_CLASS_DOC)
       .def(py::init(&HDTDocument::create), py::arg("file"),
@@ -110,6 +145,17 @@ PYBIND11_MODULE(hdt, m) {
            py::arg("id"), py::arg("position"))
      .def("convert_term", &HDTDocument::convertTerm, HDT_DOCUMENT_CONVERT_TERM_DOC,
           py::arg("term"), py::arg("position"))
+      // ========= BYTES REPRESENTATION =========
+      .def("search_triples_bytes", &HDTDocument::searchBytes,
+           HDT_DOCUMENT_SEARCH_TRIPLES_DOC, py::arg("subject"),
+           py::arg("predicate"), py::arg("object"), py::arg("limit") = 0,
+           py::arg("offset") = 0)
+      .def("search_join_bytes", &HDTDocument::searchJoinBytes, HDT_DOCUMENT_SEARCH_JOIN_DOC, py::arg("patterns"))
+      .def("convert_tripleid_bytes", &HDTDocument::convertTripleIDBytes,
+           HDT_DOCUMENT_TRIPLES_IDS_TO_STRING_DOC,
+           py::arg("subject"), py::arg("predicate"), py::arg("object"))
+      .def("convert_id_bytes", &HDTDocument::convertIDBytes, HDT_DOCUMENT_CONVERT_ID_DOC,
+           py::arg("id"), py::arg("position"))
       .def("__len__", &HDTDocument::getNbTriples, HDT_DOCUMENT_GETNBTRIPLES_DOC)
       .def("__repr__", &HDTDocument::python_repr);
 

--- a/src/join_iterator_bytes.cpp
+++ b/src/join_iterator_bytes.cpp
@@ -1,0 +1,80 @@
+/**
+ * join_iterator_bytes.cpp
+ * Author: Thomas MINIER - MIT License 2017-2019
+ */
+
+#include "join_iterator_bytes.hpp"
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+/*!
+ * Constructor
+ * @param _it [description]
+ */
+JoinIteratorBytes::JoinIteratorBytes(hdt::VarBindingString *_it) : iterator(_it) {}
+
+/*!
+ * Destructor
+ */
+JoinIteratorBytes::~JoinIteratorBytes() {
+  delete iterator;
+}
+
+/*!
+ * Implementation for Python function "__repr__"
+ * @return [description]
+ */
+std::string JoinIteratorBytes::python_repr() {
+  return "JoinIteratorBytes";
+}
+
+
+/*!
+ * Implementation for Python function "__iter__"
+ * @return [description]
+ */
+JoinIteratorBytes *JoinIteratorBytes::python_iter() { return this; }
+
+/**
+ * Get the estimated join cardinality
+ * @return [description]
+ */
+size_t JoinIteratorBytes::estimatedCardinality() {
+  return iterator->estimatedNumResults();
+}
+
+/**
+ * Reset the iterator into its initial state and restart join processing.
+ */
+void JoinIteratorBytes::reset() {
+  iterator->goToStart();
+}
+
+/*!
+ * Return true if the iterator still has items available, False otherwise.
+ * @return [description]
+ */
+bool JoinIteratorBytes::hasNext() {
+  return hasNextSolution;
+}
+
+/**
+ * Return the next set of solutions bindings, or raise py::StopIteration if the iterator
+ * has ended. Used to implement Python Itertor protocol.
+ * @return [description]
+ */
+py::set JoinIteratorBytes::next() {
+  hasNextSolution = iterator->findNext();
+  // stop iteration if the iterator has ended
+  if (!hasNextSolution) {
+    throw pybind11::stop_iteration();
+  }
+  solution_bindings_bytes solutions_bytes;
+  // build solution bindings
+  for(unsigned int i = 0; i < iterator->getNumVars(); i++) {
+    std::string varname = iterator->getVarName(i);
+    std::string value = iterator->getVar(i);
+    solutions_bytes.add(std::make_tuple(py::bytes(varname), py::bytes(value)));
+  }
+  return solutions_bytes;
+}

--- a/src/triple_iterator_bytes.cpp
+++ b/src/triple_iterator_bytes.cpp
@@ -1,0 +1,129 @@
+/**
+ * triple_iterator_bytes.cpp
+ * Author: Arnaud GRALL - MIT License 2017-2019
+ */
+
+#include "triple_iterator_bytes.hpp"
+#include <HDTEnums.hpp>
+#include <SingleTriple.hpp>
+#include <pybind11/pybind11.h>
+namespace py = pybind11;
+
+/*!
+ * Constructor
+ * @param iterator [description]
+ */
+TripleIteratorBytes::TripleIteratorBytes(TripleIDIterator *_it, hdt::Dictionary *_dict)
+    : iterator(_it), dictionary(_dict) {};
+
+/*!
+ * Destructor
+ */
+TripleIteratorBytes::~TripleIteratorBytes() { delete iterator; };
+
+/*!
+ * Implementation for Python function "__repr__"
+ * @return [description]
+ */
+std::string TripleIteratorBytes::python_repr() {
+  if (getLimit() != 0 && getOffset() > 0) {
+    return "<Iterator {" + getSubject() + " " + getPredicate() + " " + getObject() +
+           "} LIMIT " + std::to_string(getLimit()) + " OFFSET " +
+           std::to_string(getOffset()) + " >";
+  } else if (getLimit() != 0) {
+    return "<Iterator {" + getSubject() + " " + getPredicate() + " " + getObject() +
+           "} LIMIT " + std::to_string(getLimit()) + " >";
+  } else if (getOffset() > 0) {
+    return "<Iterator {" + getSubject() + " " + getPredicate() + " " + getObject() +
+           "} OFFSET " + std::to_string(getOffset()) + ">";
+  }
+  return "<Iterator {" + getSubject() + " " + getPredicate() + " " + getObject() + "}>";
+}
+
+/*!
+ * Get the subject of the triple pattern currently evaluated.
+ * An empty string represents a variable
+ * @return [description]
+ */
+std::string TripleIteratorBytes::getSubject() { return iterator->getSubject(); }
+
+/*!
+ * Get the predicate of the triple pattern currently evaluated.
+ * An empty string represents a variable
+ * @return [description]
+ */
+std::string TripleIteratorBytes::getPredicate() { return iterator->getPredicate(); }
+
+/*!
+ * Get the object of the triple pattern currently evaluated.
+ * An empty string represents a variable
+ * @return [description]
+ */
+std::string TripleIteratorBytes::getObject() { return iterator->getObject(); }
+
+/*!
+ * Get the limit of the current iterator
+ * @return [description]
+ */
+unsigned int TripleIteratorBytes::getLimit() { return iterator->getLimit(); }
+
+/*!
+ * Get the offset of the current iterator
+ * @return [description]
+ */
+unsigned int TripleIteratorBytes::getOffset() { return iterator->getOffset(); }
+
+/*!
+ * Get the number of results read by the iterator
+ * @return [description]
+ */
+unsigned int TripleIteratorBytes::getNbResultsRead() { return iterator->getNbResultsRead(); }
+
+/*!
+ * Implementation for Python function "__iter__"
+ * @return [description]
+ */
+TripleIteratorBytes *TripleIteratorBytes::python_iter() { return this; }
+
+/*!
+ * Get a hint over the cardinality of the triple pattern evaluated.
+ * Offset & limit are not taken into account.
+ * @return [description]
+ */
+size_hint TripleIteratorBytes::sizeHint() {
+  return iterator->sizeHint();
+}
+
+/*!
+ * Return true if the iterator still has items available, False otherwise.
+ * @return [description]
+ */
+bool TripleIteratorBytes::hasNext() {
+  return iterator->hasNext();
+}
+
+/**
+ * Get the next item in the iterator, or raise py::StopIteration if the iterator
+ * has ended. Used to implement Python Itertor protocol.
+ * @return [description]
+ */
+triple_bytes TripleIteratorBytes::next() {
+  triple_id t = iterator->next();
+  return std::make_tuple(
+    py::bytes(dictionary->idToString(std::get<0>(t), hdt::SUBJECT)),
+    py::bytes(dictionary->idToString(std::get<1>(t), hdt::PREDICATE)),
+    py::bytes(dictionary->idToString(std::get<2>(t), hdt::OBJECT)));
+}
+
+/**
+ * Get the next item in the iterator, or raise py::StopIteration if the iterator
+ * has ended, but without advancing the iterator.
+ * @return [description]
+ */
+triple_bytes TripleIteratorBytes::peek() {
+  triple_id t = iterator->peek();
+  return std::make_tuple(
+    py::bytes(dictionary->idToString(std::get<0>(t), hdt::SUBJECT)),
+    py::bytes(dictionary->idToString(std::get<1>(t), hdt::PREDICATE)),
+    py::bytes(dictionary->idToString(std::get<2>(t), hdt::OBJECT)));
+}

--- a/tests/hdt_document_test.py
+++ b/tests/hdt_document_test.py
@@ -50,6 +50,19 @@ def test_ids_to_string():
         assert pred == p
         assert obj == o
 
+def test_ids_to_string_bytes():
+    (triples, triplesCard) = document.search_triples_bytes("", "", "")
+    (ids, idsCard) = document.search_triples_ids(0, 0, 0)
+    assert triplesCard == idsCard
+    assert triplesCard == nbTotalTriples
+    for subj, pred, obj in triples:
+        print(subj, pred, obj)
+        sid, pid, oid = next(ids)
+        s, p, o = document.convert_tripleid_bytes(sid, pid, oid)
+        assert subj.decode('utf-8') == s.decode('utf-8')
+        assert pred.decode('utf-8') == p.decode('utf-8')
+        assert obj.decode('utf-8') == o.decode('utf-8')
+
 
 def test_convert_id():
     (triples, triplesCard) = document.search_triples("", "", "")
@@ -62,6 +75,22 @@ def test_convert_id():
             document.convert_id(sid, IdentifierPosition.Subject),
             document.convert_id(pid, IdentifierPosition.Predicate),
             document.convert_id(oid, IdentifierPosition.Object)
+            )
+        assert subj == s
+        assert pred == p
+        assert obj == o
+
+def test_convert_id_bytes():
+    (triples, triplesCard) = document.search_triples_bytes("", "", "")
+    (ids, idsCard) = document.search_triples_ids(0, 0, 0)
+    assert triplesCard == idsCard
+    assert triplesCard == nbTotalTriples
+    for subj, pred, obj in triples:
+        sid, pid, oid = next(ids)
+        s, p, o = (
+            document.convert_id_bytes(sid, IdentifierPosition.Subject),
+            document.convert_id_bytes(pid, IdentifierPosition.Predicate),
+            document.convert_id_bytes(oid, IdentifierPosition.Object)
             )
         assert subj == s
         assert pred == p

--- a/tests/hdt_iterators_test.py
+++ b/tests/hdt_iterators_test.py
@@ -20,6 +20,26 @@ def test_read_document_base():
         assert obj is not None
     assert triples.nb_reads == cardinality
 
+def test_read_document_base_bytes():
+    (triples, cardinality) = document.search_triples_bytes("", "", "")
+    assert triples.subject == "?s"
+    assert triples.predicate == "?p"
+    assert triples.object == "?o"
+    assert cardinality == nbTotalTriples
+    for subj, pred, obj in triples:
+        assert isinstance(subj, bytes)
+        assert isinstance(pred, bytes)
+        assert isinstance(obj, bytes)
+        try:
+            s, p, o = subj.decode('utf-8'), pred.decode('utf-8'), obj.decode('utf-8')
+        except Exception as err:
+            # with the test.hdt file we shouldnt have any problem
+            raise err
+        assert subj is not None
+        assert pred is not None
+        assert obj is not None
+    assert triples.nb_reads == cardinality
+
 
 empty_triples = [
     ("http://example.org#toto", "", ""),
@@ -60,6 +80,30 @@ def test_read_document_limit():
         assert subj is not None
         assert pred is not None
         assert obj is not None
+    assert nbItems == 10
+    assert triples.nb_reads == 10
+
+def test_read_document_bytes_peek():
+    nbItems = 0
+    (triples, cardinality) = document.search_triples_bytes("", "", "", limit=10)
+    assert triples.limit == 10
+    assert cardinality == nbTotalTriples
+    peek = triples.peek()
+    for subj, pred, obj in triples:
+        nbItems += 1
+        assert isinstance(subj, bytes)
+        assert isinstance(pred, bytes)
+        assert isinstance(obj, bytes)
+        assert subj == peek[0]
+        assert pred == peek[1]
+        assert obj == peek[2]
+        assert subj is not None
+        assert pred is not None
+        assert obj is not None
+        try:
+            peek = triples.peek()
+        except:
+            pass
     assert nbItems == 10
     assert triples.nb_reads == 10
 

--- a/tests/join_iterator_test.py
+++ b/tests/join_iterator_test.py
@@ -17,3 +17,15 @@ def test_basic_join():
         assert len(b) == 1
         assert ('?s', 'http://example.org/s1') in b or ('?s', 'http://example.org/s2') in b
     assert cpt == 2
+
+def test_basic_join_bytes():
+    join_iter = document.search_join_bytes([
+        ("?s", "http://example.org/p1", "http://example.org/o001"),
+        ("?s", "http://example.org/p1", "http://example.org/o001")
+    ])
+    cpt = 0
+    for b in join_iter:
+        cpt += 1
+        assert len(b) == 1
+        assert (b'?s', b'http://example.org/s1') in b or (b'?s', b'http://example.org/s2') in b
+    assert cpt == 2


### PR DESCRIPTION
Sometimes a `UnicodeDecodeError ` happens when iterating on the HDT file. Python automatically transforms any string from c++ to UTF-8 string in python. Due to this, if the data has been encoded with an old codec (eg: CESU-8, https://stackoverflow.com/questions/58464865/enable-to-decode-encode-correctly-from-bytes-in-python) or any other codec, it will end with the `UnicodeDecodeError `.
To handle this I doubled the API of the HDT document by adding:
- `search_triples_bytes(...)` return an iterator of triples as `(py::bytes, py::bytes, py::bytes)`
- `search_join_bytes(...)` return an iterator of sets of solutions mapping as `py::set(py::bytes, py::bytes)`
- `convert_tripleid_bytes(...)` return a triple as: `(py::bytes, py::bytes, py::bytes)`
- `convert_id_bytes(...)` return a `py::bytes`

It is a non breaking API change so you can use the library as before. And switch to those functions if there is an `UnicodeDecodeError `. 

Tests have been modified.
Documentation file (.rst) have been modified as well as the Readme.rst file.
No documentation about the `JoinIteratorBytes` and the `TripleIteratorBytes` because it is the exactly the same api. We just return bytes instead of string.

Have fun!